### PR TITLE
added ruff formatter for python

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@
 - [perltidy](https://github.com/perltidy/perltidy)
 - [qmlformat](https://github.com/qt/qtdeclarative)
 - [rubocop](https://github.com/rubocop/rubocop)
+- [ruff](https://docs.astral.sh/ruff/formatter)
 - [rustfmt](https://github.com/rust-lang/rustfmt)
 - [shformat](https://github.com/mvdan/sh)
 - [sql-formatter](https://github.com/sql-formatter-org/sql-formatter)

--- a/formatters/ruff.lua
+++ b/formatters/ruff.lua
@@ -1,0 +1,7 @@
+-- for ruff python formatter
+
+return {
+  label = "Ruff",
+  file_patterns = {"%.pyi?$"},
+  command = {"ruff", "format", "$ARGS", "$FILENAME"}
+}


### PR DESCRIPTION
Add support for ruff formatter for python, using `ruff format $ARGS $FILENAME`